### PR TITLE
Oppdaterte veilarbveileder url til å være uavhengig av namespace

### DIFF
--- a/src/main/no/nav/pto/veilarbfilter/config/Configuration.kt
+++ b/src/main/no/nav/pto/veilarbfilter/config/Configuration.kt
@@ -3,6 +3,7 @@ package no.nav.pto.veilarbfilter.config
 import com.auth0.jwk.JwkProvider
 import com.natpryce.konfig.*
 import no.nav.common.utils.Credentials
+import no.nav.common.utils.EnvironmentUtils.isProduction
 import no.nav.common.utils.EnvironmentUtils.requireNamespace
 import no.nav.common.utils.NaisUtils.getCredentials
 import no.nav.pto.veilarbfilter.JwtUtil
@@ -53,7 +54,9 @@ data class Configuration(
     )
 
     data class VeilarbveilederConfig(
-        val url: String = "http://veilarbveileder.${requireNamespace()}.svc.nais.local/veilarbveileder"
+        val url: String =
+            if (isProduction().orElseThrow()) "https://veilarbveileder.nais.adeo.no/veilarbveileder"
+            else String.format("https://veilarbveileder-%s.nais.preprod.local/veilarbveileder", requireNamespace())
     )
 }
 


### PR DESCRIPTION
Når veilarbveileder bytter namespace til 'pto' så vil service urler brekke.