### PR TITLE
TC-260 Legg til støtte for avvik14aVedtak-filter

### DIFF
--- a/src/main/java/no/nav/pto/veilarbfilter/domene/PortefoljeFilter.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/domene/PortefoljeFilter.java
@@ -107,6 +107,9 @@ public class PortefoljeFilter {
     @JsonSetter(nulls = Nulls.AS_EMPTY)
     private List<String> visGeografiskBosted = emptyList();
 
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    private List<String> avvik14aVedtak = emptyList();
+
 
     @JsonIgnore
     public Boolean isNotEmpty() {
@@ -139,6 +142,7 @@ public class PortefoljeFilter {
                 (tolkBehovSpraak != null && !tolkBehovSpraak.isEmpty()) ||
                 (stillingFraNavFilter != null && !stillingFraNavFilter.isEmpty()) ||
                 (visGeografiskBosted != null && !visGeografiskBosted.isEmpty()) ||
-                (geografiskBosted != null && !geografiskBosted.isEmpty());
+                (geografiskBosted != null && !geografiskBosted.isEmpty()) ||
+                (avvik14aVedtak != null && !avvik14aVedtak.isEmpty());
     }
 }

--- a/src/test/java/no/nav/pto/veilarbfilter/domene/PortefoljeFilterTest.java
+++ b/src/test/java/no/nav/pto/veilarbfilter/domene/PortefoljeFilterTest.java
@@ -99,7 +99,7 @@ class PortefoljeFilterTest {
     @Test
     public void testSerializationOfEmptyFilter() throws JsonProcessingException {
         String correctOutput = """
-                {"aktiviteter":null,"aktiviteterForenklet":[],"alder":[],"arbeidslisteKategori":[],"cvJobbprofil":"","ferdigfilterListe":[],"fodselsdagIMnd":[],"foedeland":[],"formidlingsgruppe":[],"geografiskBosted":[],"hovedmal":[],"innsatsgruppe":[],"kjonn":"","landgruppe":[],"manuellBrukerStatus":[],"navnEllerFnrQuery":"","registreringstype":[],"rettighetsgruppe":[],"servicegruppe":[],"sisteEndringKategori":[],"stillingFraNavFilter":[],"tiltakstyper":[],"tolkBehovSpraak":[],"tolkebehov":[],"ulesteEndringer":"","utdanning":[],"utdanningBestatt":[],"utdanningGodkjent":[],"veilederNavnQuery":"","veiledere":[],"visGeografiskBosted":[],"ytelse":""}""";
+                {"aktiviteter":null,"aktiviteterForenklet":[],"alder":[],"arbeidslisteKategori":[],"avvik14aVedtak":[],"cvJobbprofil":"","ferdigfilterListe":[],"fodselsdagIMnd":[],"foedeland":[],"formidlingsgruppe":[],"geografiskBosted":[],"hovedmal":[],"innsatsgruppe":[],"kjonn":"","landgruppe":[],"manuellBrukerStatus":[],"navnEllerFnrQuery":"","registreringstype":[],"rettighetsgruppe":[],"servicegruppe":[],"sisteEndringKategori":[],"stillingFraNavFilter":[],"tiltakstyper":[],"tolkBehovSpraak":[],"tolkebehov":[],"ulesteEndringer":"","utdanning":[],"utdanningBestatt":[],"utdanningGodkjent":[],"veilederNavnQuery":"","veiledere":[],"visGeografiskBosted":[],"ytelse":""}""";
         PortefoljeFilter portefoljeFilter = new PortefoljeFilter();
         String jsonString = objectMapper.writeValueAsString(portefoljeFilter);
         Assertions.assertEquals(jsonString, correctOutput);
@@ -108,10 +108,10 @@ class PortefoljeFilterTest {
     @Test
     public void testSerializationOfVeiledere() throws JsonProcessingException {
         String correctOutput = """
-                {"aktiviteter":null,"aktiviteterForenklet":null,"alder":null,"arbeidslisteKategori":null,"cvJobbprofil":null,"ferdigfilterListe":null,"fodselsdagIMnd":null,"foedeland":null,"formidlingsgruppe":null,"geografiskBosted":null,"hovedmal":null,"innsatsgruppe":null,"kjonn":null,"landgruppe":null,"manuellBrukerStatus":null,"navnEllerFnrQuery":null,"registreringstype":null,"rettighetsgruppe":null,"servicegruppe":null,"sisteEndringKategori":null,"stillingFraNavFilter":null,"tiltakstyper":null,"tolkBehovSpraak":null,"tolkebehov":null,"ulesteEndringer":null,"utdanning":null,"utdanningBestatt":null,"utdanningGodkjent":null,"veilederNavnQuery":null,"veiledere":["A123","B123"],"visGeografiskBosted":null,"ytelse":null}""";
+                {"aktiviteter":null,"aktiviteterForenklet":null,"alder":null,"arbeidslisteKategori":null,"avvik14aVedtak":null,"cvJobbprofil":null,"ferdigfilterListe":null,"fodselsdagIMnd":null,"foedeland":null,"formidlingsgruppe":null,"geografiskBosted":null,"hovedmal":null,"innsatsgruppe":null,"kjonn":null,"landgruppe":null,"manuellBrukerStatus":null,"navnEllerFnrQuery":null,"registreringstype":null,"rettighetsgruppe":null,"servicegruppe":null,"sisteEndringKategori":null,"stillingFraNavFilter":null,"tiltakstyper":null,"tolkBehovSpraak":null,"tolkebehov":null,"ulesteEndringer":null,"utdanning":null,"utdanningBestatt":null,"utdanningGodkjent":null,"veilederNavnQuery":null,"veiledere":["A123","B123"],"visGeografiskBosted":null,"ytelse":null}""";
         PortefoljeFilter portefoljeFilter = new PortefoljeFilter(null, null, null, null, null, null, null, null, null, null,
                 null, null, null, null, List.of("A123", "B123"), null, null, null, null, null, null, null, null, null, null,
-                null, null, null, null, null,null, null);
+                null, null, null, null, null,null, null, null);
         String jsonString = objectMapper.writeValueAsString(portefoljeFilter);
         Assertions.assertEquals(jsonString, correctOutput);
     }

--- a/src/test/java/no/nav/pto/veilarbfilter/rest/MineLagredeFilterTest.java
+++ b/src/test/java/no/nav/pto/veilarbfilter/rest/MineLagredeFilterTest.java
@@ -415,7 +415,7 @@ public class MineLagredeFilterTest extends AbstractTest {
                 emptyList(), emptyList(), emptyList(), emptyList(), kjonnVelg.get(random.nextInt(1)), emptyList(),
                 String.valueOf(rndChar()), emptyList(), emptyList(), emptyList(), "", emptyList(), "", emptyList(), "",
                 emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), "", emptyList(), emptyList(), emptyList(),
-                emptyList(), emptyList(), emptyList(), emptyList(), emptyList());
+                emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList());
     }
 
     private static char rndChar() {

--- a/src/test/java/no/nav/pto/veilarbfilter/rest/VeilederGruppeTest.java
+++ b/src/test/java/no/nav/pto/veilarbfilter/rest/VeilederGruppeTest.java
@@ -214,6 +214,6 @@ public class VeilederGruppeTest extends AbstractTest {
     public PortefoljeFilter getRandomPortefoljeFilter(List<String> veiledersList) {
         return new PortefoljeFilter(null, emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), "",
                 emptyList(), "", emptyList(), emptyList(), emptyList(), "", veiledersList, "", emptyList(), "", emptyList(),
-                emptyList(), emptyList(), emptyList(), emptyList(), "", emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList());
+                emptyList(), emptyList(), emptyList(), emptyList(), "", emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList());
     }
 }


### PR DESCRIPTION
Legger til støtte for å kunne lagre `avvik14aFilter`. Denne må deployes samtidig med [endringen i veilarbportefoljeflatefs](https://github.com/navikt/veilarbportefoljeflatefs/pull/773).