### PR TITLE
TC-320 Gi alle AzureAD-brukere tilgang i prod

### DIFF
--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -25,6 +25,7 @@ spec:
     timeout: 10
   azure:
     application:
+      allowAllUsers: true
       enabled: true
       claims:
         extra:


### PR DESCRIPTION
Ref. endring i default brukertilganger for AzureAD, som annonsert i #nais-announcements: https://nav-it.slack.com/archives/C01DE3M9YBV/p1674475818557619