### PR TITLE
TC-579 Gi token-generator tilgang i dev

### DIFF
--- a/.nais/application/application-config-dev.yaml
+++ b/.nais/application/application-config-dev.yaml
@@ -52,6 +52,9 @@ spec:
         - application: veilarbpersonflate
           namespace: poao
           cluster: dev-gcp
+        - application: azure-token-generator
+          namespace: aura
+          cluster: dev-gcp
   resources:
     limits:
       cpu: "1"


### PR DESCRIPTION
Gir token-generator tilgang i dev slik at vi kan generere access-tokens on-demand.

Fra [NAIS-docen](https://doc.nais.io/security/auth/azure-ad/usage/#token-generator):

> In many cases, you want to locally develop and test against a secured API in the development environments. To do so, you need a [token](https://doc.nais.io/security/auth/concepts/#bearer-token) to access said API.