### PR TITLE
For at filtre som eventuelt har gamle registreringssituasjoner

### DIFF
--- a/src/main/java/no/nav/pto/veilarbfilter/domene/PortefoljeFilter.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/domene/PortefoljeFilter.java
@@ -62,6 +62,7 @@ public class PortefoljeFilter {
     private String ytelse = "";
 
     @JsonSetter(nulls = Nulls.AS_EMPTY)
+    @Setter
     private List<String> registreringstype = emptyList();
 
     private String cvJobbprofil = "";


### PR DESCRIPTION
Fordi vi bare må få ut endringer i arbeidssøkerregistreringen nå er det tatt et valg om å mappe om "ulovlige filter" i registreringstyper ved henting av filter. Ved å gjøre det her vil alle endringer som gjøres i filtere sørge for at de nye enumene blir satt i filteret ved oppdatering også. 
Mulig vi kan se på å mappe i selve databasen på sikt. 