### PR TITLE
Migrer registreringstyper

### DIFF
--- a/src/main/java/no/nav/pto/veilarbfilter/domene/value/NyeRegistreringstyper.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/domene/value/NyeRegistreringstyper.java
@@ -1,0 +1,17 @@
+package no.nav.pto.veilarbfilter.domene.value;
+
+public enum NyeRegistreringstyper {
+    AKKURAT_FULLFORT_UTDANNING,
+    ALDRI_HATT_JOBB,
+    ANNET,
+    DELTIDSJOBB_VIL_MER,
+    ER_PERMITTERT,
+    HAR_BLITT_SAGT_OPP,
+    HAR_SAGT_OPP,
+    IKKE_VAERT_I_JOBB_SISTE_2_AAR,
+    KONKURS,
+    MIDLERTIDIG_JOBB,
+    NY_JOBB,
+    USIKKER_JOBBSITUASJON,
+    VIL_BYTTE_JOBB,
+}

--- a/src/main/java/no/nav/pto/veilarbfilter/domene/value/UtdaterteRegistreringstyper.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/domene/value/UtdaterteRegistreringstyper.java
@@ -1,0 +1,13 @@
+package no.nav.pto.veilarbfilter.domene.value;
+
+public enum UtdaterteRegistreringstyper {
+    MISTET_JOBBEN,
+    OPPSIGELSE,
+    JOBB_OVER_2_AAR,
+    VIL_FORTSETTE_I_JOBB,
+    INGEN_SVAR,
+    INGEN_VERDI,
+    ENDRET_PERMITTERINGSPROSENT,
+    TILBAKE_TIL_JOBB,
+    SAGT_OPP
+}

--- a/src/main/java/no/nav/pto/veilarbfilter/domene/value/UtdaterteRegistreringstyper.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/domene/value/UtdaterteRegistreringstyper.java
@@ -2,12 +2,6 @@ package no.nav.pto.veilarbfilter.domene.value;
 
 public enum UtdaterteRegistreringstyper {
     MISTET_JOBBEN,
-    OPPSIGELSE,
     JOBB_OVER_2_AAR,
     VIL_FORTSETTE_I_JOBB,
-    INGEN_SVAR,
-    INGEN_VERDI,
-    ENDRET_PERMITTERINGSPROSENT,
-    TILBAKE_TIL_JOBB,
-    SAGT_OPP
 }

--- a/src/main/java/no/nav/pto/veilarbfilter/repository/FilterRepository.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/repository/FilterRepository.java
@@ -27,6 +27,7 @@ public class FilterRepository {
     public static final String ARENA_INNSATSGRUPPE_FILTERVALG_JSON_KEY = "innsatsgruppe";
     public static final String GJELDENDE_VEDTAK_HOVEDMAL_FILTERVALG_JSON_KEY = "hovedmalGjeldendeVedtak14a";
     public static final String GJELDENDE_VEDTAK_INNSATSGRUPPE_FILTERVALG_JSON_KEY = "innsatsgruppeGjeldendeVedtak14a";
+    public static final String REGISTRERINGSTYPE_FILTERVALG_JSON_KEY = "registreringstype";
 
     private final JdbcTemplate db;
     private final ObjectMapper objectMapper;

--- a/src/main/java/no/nav/pto/veilarbfilter/repository/FilterRepository.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/repository/FilterRepository.java
@@ -115,6 +115,30 @@ public class FilterRepository {
         return db.query(sqlHentAntall, this::mapTilFilterModel, filtervalg, antallSomSkalHentes);
     }
 
+    public List<FilterModel> hentMineFilterSomInneholderUtdaterteRegistreringstyper() {
+        //language=postgresql
+        String sqlHentAlle = String.format("""
+                        SELECT %s, %s, %s, %s, %s
+                        FROM (SELECT *, %s ->> 'registreringstype'
+                                         AS liste_for_filtertype
+                              FROM %s)
+                                 AS filter_som_skal_telles
+                        WHERE liste_for_filtertype != '[]'
+                          AND liste_for_filtertype::jsonb ?| array [
+                            'MISTET_JOBBEN',
+                            'JOBB_OVER_2_AAR',
+                            'VIL_FORTSETTE_I_JOBB'
+                            ];
+                        """,
+                Filter.FILTER_ID, Filter.FILTER_NAVN, Filter.VALGTE_FILTER, Filter.OPPRETTET, Filter.FILTER_CLEANUP,
+                Filter.VALGTE_FILTER,
+                Filter.TABLE_NAME
+        );
+
+        return db.query(sqlHentAlle, this::mapTilFilterModel);
+    }
+
+
     // Denne funksjonen bør kun brukast ifm. migrering av filter
     private FilterModel mapTilFilterModel(ResultSet rs, int rowNum) {
         try {

--- a/src/main/java/no/nav/pto/veilarbfilter/repository/MineLagredeFilterRepository.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/repository/MineLagredeFilterRepository.java
@@ -90,7 +90,7 @@ public class MineLagredeFilterRepository implements FilterService {
 
     @Override
     public Optional<FilterModel> hentFilter(Integer filterId) {
-        return hentFilter(filterId, false);
+        return hentFilter(filterId, true);
     }
 
     public Optional<FilterModel> hentFilter(Integer filterId, boolean mapRegistreringstypeTilNyeNavn) {

--- a/src/main/java/no/nav/pto/veilarbfilter/repository/MineLagredeFilterRepository.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/repository/MineLagredeFilterRepository.java
@@ -306,12 +306,9 @@ public class MineLagredeFilterRepository implements FilterService {
 
     private String mapSituasjonTilBeskrivelse(String situasjon) {
         return switch (situasjon) {
-            case "MISTET_JOBBEN", "OPPSIGELSE" -> "HAR_BLITT_SAGT_OPP";
+            case "MISTET_JOBBEN" -> "HAR_BLITT_SAGT_OPP";
             case "JOBB_OVER_2_AAR" -> "IKKE_VAERT_I_JOBB_SISTE_2_AAR";
             case "VIL_FORTSETTE_I_JOBB" -> "ANNET";
-            case "INGEN_SVAR", "INGEN_VERDI" -> "UDEFINERT";
-            case "ENDRET_PERMITTERINGSPROSENT", "TILBAKE_TIL_JOBB" -> "ER_PERMITTERT";
-            case "SAGT_OPP" -> "HAR_SAGT_OPP";
             default -> situasjon;
         };
     }

--- a/src/main/java/no/nav/pto/veilarbfilter/repository/MineLagredeFilterRepository.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/repository/MineLagredeFilterRepository.java
@@ -90,7 +90,7 @@ public class MineLagredeFilterRepository implements FilterService {
 
     @Override
     public Optional<FilterModel> hentFilter(Integer filterId) {
-        return hentFilter(filterId, true);
+        return hentFilter(filterId, false);
     }
 
     public Optional<FilterModel> hentFilter(Integer filterId, boolean mapRegistreringstypeTilNyeNavn) {

--- a/src/main/java/no/nav/pto/veilarbfilter/service/MigrerFilterService.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/service/MigrerFilterService.java
@@ -49,29 +49,22 @@ public class MigrerFilterService {
     public Optional<FilterMigreringResultat> migrerFilter(int batchStorrelseForJobb) {
         log.info("Filtermigrering - Batch startet");
 
-        int antallFilterMedFilterverdiArenaHovedmal = filterRepository.tellMineFilterSomInneholderEnBestemtFiltertype(ARENA_HOVEDMAL_FILTERVALG_JSON_KEY);
-        int antallFilterMedFilterverdiArenaInnsatsgruppe = filterRepository.tellMineFilterSomInneholderEnBestemtFiltertype(ARENA_INNSATSGRUPPE_FILTERVALG_JSON_KEY);
         int antallFilterMedUtdaterteRegistreringstyper = filterRepository.hentMineFilterSomInneholderUtdaterteRegistreringstyper().size();
 
-        if (antallFilterMedFilterverdiArenaHovedmal == 0 && antallFilterMedFilterverdiArenaInnsatsgruppe == 0 && antallFilterMedUtdaterteRegistreringstyper == 0) {
+        if (antallFilterMedUtdaterteRegistreringstyper == 0) {
             log.info("Filtermigrering - Ingen filter å migrere");
             log.info("Filtermigrering - Batch fullført");
             return Optional.empty();
         }
 
-        log.info("Filtermigrering - Totalt antall filter med hovedmål: {}, innsatsgruppe: {}", antallFilterMedFilterverdiArenaHovedmal, antallFilterMedFilterverdiArenaInnsatsgruppe);
         log.info("Filtermigrering - Totalt antall filter med utdaterte registreringstyper: {}", antallFilterMedUtdaterteRegistreringstyper);
 
         try {
-            Optional<Migrert> resultatHovedmalMigrering = antallFilterMedFilterverdiArenaHovedmal > 0 ? Optional.of(migrerFilterMedFiltertype(batchStorrelseForJobb, ARENA_HOVEDMAL_FILTERVALG_JSON_KEY)) : Optional.empty();
-            Optional<Migrert> resultatInnsatsgruppeMigrering = antallFilterMedFilterverdiArenaInnsatsgruppe > 0 ? Optional.of(migrerFilterMedFiltertype(batchStorrelseForJobb, ARENA_INNSATSGRUPPE_FILTERVALG_JSON_KEY)) : Optional.empty();
             Optional<Migrert> resultatRegistreringstyperMigrering = antallFilterMedUtdaterteRegistreringstyper > 0 ? Optional.of(migrerFilterMedUtdaterteRegistreringstyper(batchStorrelseForJobb)) : Optional.empty();
             log.info("Filtermigrering - Batch fullført");
 
             return Optional.of(
                     new FilterMigreringResultat(
-                            resultatHovedmalMigrering.flatMap(it -> Optional.of(new FilterMigreringResultat.Resultat(antallFilterMedFilterverdiArenaHovedmal, it.forsokt, it.faktisk))),
-                            resultatInnsatsgruppeMigrering.flatMap(it -> Optional.of(new FilterMigreringResultat.Resultat(antallFilterMedFilterverdiArenaInnsatsgruppe, it.forsokt, it.faktisk))),
                             resultatRegistreringstyperMigrering.flatMap(it -> Optional.of(new FilterMigreringResultat.Resultat(antallFilterMedUtdaterteRegistreringstyper, it.forsokt, it.faktisk)))
                     )
             );
@@ -242,8 +235,6 @@ public class MigrerFilterService {
     }
 
     public record FilterMigreringResultat(
-            Optional<Resultat> hovedmal,
-            Optional<Resultat> innsatsgruppe,
             Optional<Resultat> registreringstyper
     ) {
 

--- a/src/main/java/no/nav/pto/veilarbfilter/service/MigrerFilterService.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/service/MigrerFilterService.java
@@ -30,16 +30,16 @@ import static no.nav.pto.veilarbfilter.util.SecureLogUtils.secureLog;
 @RequiredArgsConstructor
 public class MigrerFilterService {
     public static final int BATCH_STORRELSE_ALLE = -1;
-    private static final int DEFAULT_BATCHSTORRELSE_FOR_JOBB = 100;
-    private static final int ET_MINUTT = 1;
-    private static final int TI_MINUTT = 10;
+    private static final int DEFAULT_BATCHSTORRELSE_FOR_JOBB = 2;
+    private static final int ET_MINUTT = 60;
+    private static final int TI_SEKUND = 10;
 
     private final LeaderElectionClient leaderElectionClient;
     private final FilterRepository filterRepository;
     private final ObjectMapper objectMapper;
     private final DefaultUnleash defaultUnleash;
 
-    @Scheduled(initialDelay = ET_MINUTT, fixedRate = TI_MINUTT, timeUnit = TimeUnit.MINUTES)
+    @Scheduled(initialDelay = ET_MINUTT, fixedRate = TI_SEKUND, timeUnit = TimeUnit.SECONDS)
     public void migrerFilterJobb() {
         if (leaderElectionClient.isLeader() && defaultUnleash.isEnabled(FeatureToggle.MIGRER_FILTER_JOBB_ENABLED)) {
             migrerFilter(DEFAULT_BATCHSTORRELSE_FOR_JOBB);

--- a/src/main/java/no/nav/pto/veilarbfilter/service/MigrerFilterService.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/service/MigrerFilterService.java
@@ -51,24 +51,28 @@ public class MigrerFilterService {
 
         int antallFilterMedFilterverdiArenaHovedmal = filterRepository.tellMineFilterSomInneholderEnBestemtFiltertype(ARENA_HOVEDMAL_FILTERVALG_JSON_KEY);
         int antallFilterMedFilterverdiArenaInnsatsgruppe = filterRepository.tellMineFilterSomInneholderEnBestemtFiltertype(ARENA_INNSATSGRUPPE_FILTERVALG_JSON_KEY);
+        int antallFilterMedUtdaterteRegistreringstyper = filterRepository.hentMineFilterSomInneholderUtdaterteRegistreringstyper().size();
 
-        if (antallFilterMedFilterverdiArenaHovedmal == 0 && antallFilterMedFilterverdiArenaInnsatsgruppe == 0) {
+        if (antallFilterMedFilterverdiArenaHovedmal == 0 && antallFilterMedFilterverdiArenaInnsatsgruppe == 0 && antallFilterMedUtdaterteRegistreringstyper == 0) {
             log.info("Filtermigrering - Ingen filter å migrere");
             log.info("Filtermigrering - Batch fullført");
             return Optional.empty();
         }
 
         log.info("Filtermigrering - Totalt antall filter med hovedmål: {}, innsatsgruppe: {}", antallFilterMedFilterverdiArenaHovedmal, antallFilterMedFilterverdiArenaInnsatsgruppe);
+        log.info("Filtermigrering - Totalt antall filter med utdaterte registreringstyper: {}", antallFilterMedUtdaterteRegistreringstyper);
 
         try {
             Optional<Migrert> resultatHovedmalMigrering = antallFilterMedFilterverdiArenaHovedmal > 0 ? Optional.of(migrerFilterMedFiltertype(batchStorrelseForJobb, ARENA_HOVEDMAL_FILTERVALG_JSON_KEY)) : Optional.empty();
             Optional<Migrert> resultatInnsatsgruppeMigrering = antallFilterMedFilterverdiArenaInnsatsgruppe > 0 ? Optional.of(migrerFilterMedFiltertype(batchStorrelseForJobb, ARENA_INNSATSGRUPPE_FILTERVALG_JSON_KEY)) : Optional.empty();
+            Optional<Migrert> resultatRegistreringstyperMigrering = antallFilterMedUtdaterteRegistreringstyper > 0 ? Optional.of(migrerFilterMedUtdaterteRegistreringstyper(batchStorrelseForJobb)) : Optional.empty();
             log.info("Filtermigrering - Batch fullført");
 
             return Optional.of(
                     new FilterMigreringResultat(
                             resultatHovedmalMigrering.flatMap(it -> Optional.of(new FilterMigreringResultat.Resultat(antallFilterMedFilterverdiArenaHovedmal, it.forsokt, it.faktisk))),
-                            resultatInnsatsgruppeMigrering.flatMap(it -> Optional.of(new FilterMigreringResultat.Resultat(antallFilterMedFilterverdiArenaInnsatsgruppe, it.forsokt, it.faktisk)))
+                            resultatInnsatsgruppeMigrering.flatMap(it -> Optional.of(new FilterMigreringResultat.Resultat(antallFilterMedFilterverdiArenaInnsatsgruppe, it.forsokt, it.faktisk))),
+                            resultatRegistreringstyperMigrering.flatMap(it -> Optional.of(new FilterMigreringResultat.Resultat(antallFilterMedUtdaterteRegistreringstyper, it.forsokt, it.faktisk)))
                     )
             );
         } catch (RuntimeException e) {
@@ -239,7 +243,8 @@ public class MigrerFilterService {
 
     public record FilterMigreringResultat(
             Optional<Resultat> hovedmal,
-            Optional<Resultat> innsatsgruppe
+            Optional<Resultat> innsatsgruppe,
+            Optional<Resultat> registreringstyper
     ) {
 
         public record Resultat(

--- a/src/main/java/no/nav/pto/veilarbfilter/service/MigrerFilterService.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/service/MigrerFilterService.java
@@ -98,7 +98,7 @@ public class MigrerFilterService {
     }
 
     public Migrert migrerFilterMedUtdaterteRegistreringstyper(int batchStorrelse) {
-        List<FilterModel> filtreSomSkalMigreres = filterRepository.hentMineFilterSomInneholderUtdaterteRegistreringstyper();
+        List<FilterModel> filtreSomSkalMigreres = filterRepository.hentMineFilterSomInneholderUtdaterteRegistreringstyper(batchStorrelse);
         int forsoktMigrerteFilter = filtreSomSkalMigreres.size();
 
         int faktiskMigrerteFilter = 0;

--- a/src/main/java/no/nav/pto/veilarbfilter/service/MigrerFilterService.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/service/MigrerFilterService.java
@@ -30,7 +30,7 @@ import static no.nav.pto.veilarbfilter.util.SecureLogUtils.secureLog;
 @RequiredArgsConstructor
 public class MigrerFilterService {
     public static final int BATCH_STORRELSE_ALLE = -1;
-    private static final int DEFAULT_BATCHSTORRELSE_FOR_JOBB = 2;
+    private static final int DEFAULT_BATCHSTORRELSE_FOR_JOBB = 50;
     private static final int ET_MINUTT = 60;
     private static final int TI_SEKUND = 10;
 

--- a/src/test/java/no/nav/pto/veilarbfilter/repository/MineLagredeFilterRepositoryTest.java
+++ b/src/test/java/no/nav/pto/veilarbfilter/repository/MineLagredeFilterRepositoryTest.java
@@ -249,4 +249,51 @@ public class MineLagredeFilterRepositoryTest extends AbstractTest {
         List<Integer> hentaFilterIdeer = hentaFilterMedUtdaterteRegistreringstyper.stream().map(it -> it.getFilterId()).toList();
         assertThat(hentaFilterIdeer).isEqualTo(forventaFilterIder);
     }
+
+    @Test
+    void kan_hente_ut_en_bestemt_batchstørrelse_med_filter_som_inneholder_utdaterte_registreringstyper() {
+        // given
+        String veilederId = "Z111111";
+        String veilederId2 = "Z222222";
+        List<String> alleUtdaterteRegistreringstyper = Arrays.stream(UtdaterteRegistreringstyper.values()).map(it -> it.name()).toList();
+        List<String> alleNyeRegistreringstyper = Arrays.stream(NyeRegistreringstyper.values()).map(it -> it.name()).toList();
+        List<String> alleRegistreringstyper = Stream.concat(alleUtdaterteRegistreringstyper.stream(), alleNyeRegistreringstyper.stream()).toList();
+
+        PortefoljeFilter filterMistetJobben = new PortefoljeFilter();
+        filterMistetJobben.setRegistreringstype(List.of(UtdaterteRegistreringstyper.MISTET_JOBBEN.name()));
+        PortefoljeFilter filterJobbOver2Aar = new PortefoljeFilter();
+        filterJobbOver2Aar.setRegistreringstype(List.of(UtdaterteRegistreringstyper.JOBB_OVER_2_AAR.name()));
+        PortefoljeFilter filterVilFortsetteIJobb = new PortefoljeFilter();
+        filterVilFortsetteIJobb.setRegistreringstype(List.of(UtdaterteRegistreringstyper.VIL_FORTSETTE_I_JOBB.name()));
+
+        PortefoljeFilter filterAlleUtdaterteRegistreringtypar = new PortefoljeFilter();
+        filterAlleUtdaterteRegistreringtypar.setRegistreringstype(alleUtdaterteRegistreringstyper);
+        PortefoljeFilter filterMedBådeNyeOgUtdaterteRegistreringstper = new PortefoljeFilter();
+        filterMedBådeNyeOgUtdaterteRegistreringstper.setRegistreringstype(alleRegistreringstyper);
+
+        mineLagredeFilterRepository.lagreFilter(veilederId, new NyttFilterModel("Filter 1", filterMistetJobben)).get().getFilterId();
+        mineLagredeFilterRepository.lagreFilter(veilederId2, new NyttFilterModel("Filter 2", filterJobbOver2Aar)).get().getFilterId();
+        mineLagredeFilterRepository.lagreFilter(veilederId, new NyttFilterModel("Filter 3", filterVilFortsetteIJobb)).get().getFilterId();
+        mineLagredeFilterRepository.lagreFilter(veilederId, new NyttFilterModel("Filter 4", filterAlleUtdaterteRegistreringtypar)).get().getFilterId();
+        mineLagredeFilterRepository.lagreFilter(veilederId, new NyttFilterModel("Filter 7", filterMedBådeNyeOgUtdaterteRegistreringstper)).get().getFilterId();
+
+        // when
+        int batch1 = 2;
+        int batch2 = 4;
+        int flereEnnDetErIDatabasen = 1000;
+        int såMangeViHarIDatabasen = 5;
+
+        List<FilterModel> hentTo = filterRepository.hentMineFilterSomInneholderUtdaterteRegistreringstyper(batch1);
+        List<FilterModel> hentFire = filterRepository.hentMineFilterSomInneholderUtdaterteRegistreringstyper(batch2);
+        List<FilterModel> hentFlereEnnDetErIDatabasen = filterRepository.hentMineFilterSomInneholderUtdaterteRegistreringstyper(flereEnnDetErIDatabasen);
+        List<FilterModel> hentAlleEksplisitt = filterRepository.hentMineFilterSomInneholderUtdaterteRegistreringstyper(-1);
+        List<FilterModel> hentAlleImplisitt = filterRepository.hentMineFilterSomInneholderUtdaterteRegistreringstyper();
+
+        // then
+        assertThat(hentTo.size()).isEqualTo(batch1);
+        assertThat(hentFire.size()).isEqualTo(batch2);
+        assertThat(hentFlereEnnDetErIDatabasen.size()).isEqualTo(såMangeViHarIDatabasen);
+        assertThat(hentAlleEksplisitt.size()).isEqualTo(såMangeViHarIDatabasen);
+        assertThat(hentAlleImplisitt.size()).isEqualTo(såMangeViHarIDatabasen);
+    }
 }

--- a/src/test/java/no/nav/pto/veilarbfilter/service/FilterServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbfilter/service/FilterServiceTest.java
@@ -144,7 +144,7 @@ public class FilterServiceTest extends AbstractTest {
         int filterId = mineLagredeFilterRepository.lagreFilter(veilederId, new NyttFilterModel("Filter med registreringstyper", filterMedRegistreringstyper)).get().getFilterId();
 
         // When
-        FilterModel hentetFilter = mineLagredeFilterService.hentFilter(filterId).get();
+        FilterModel hentetFilter = mineLagredeFilterRepository.hentFilter(filterId, false).get();
 
         // Then
         assertThat(hentetFilter.getFilterValg().getRegistreringstype().size()).isEqualTo(3);

--- a/src/test/java/no/nav/pto/veilarbfilter/service/MigrerFilterServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbfilter/service/MigrerFilterServiceTest.java
@@ -1,6 +1,7 @@
 package no.nav.pto.veilarbfilter.service;
 
 import no.nav.pto.veilarbfilter.AbstractTest;
+import no.nav.pto.veilarbfilter.domene.FilterModel;
 import no.nav.pto.veilarbfilter.domene.NyttFilterModel;
 import no.nav.pto.veilarbfilter.domene.PortefoljeFilter;
 import no.nav.pto.veilarbfilter.domene.value.NyeRegistreringstyper;
@@ -274,8 +275,8 @@ class MigrerFilterServiceTest extends AbstractTest {
         migrerFilterService.migrerFilterMedFiltertype(BATCH_STORRELSE_ALLE, REGISTRERINGSTYPE_FILTERVALG_JSON_KEY);
 
         // Then
-//        int  filterMedUtdaterteRegistreringstyperEtterMigrering = filterRepository.tellMineFilterSomInneholderUtdaterteRegistreringstyper();
-//        assertThat(filterMedUtdaterteRegistreringstyperEtterMigrering).isEqualTo(0);
+        List<FilterModel>  filterMedUtdaterteRegistreringstyperEtterMigrering = filterRepository.hentMineFilterSomInneholderUtdaterteRegistreringstyper();
+        assertThat(filterMedUtdaterteRegistreringstyperEtterMigrering.size()).isEqualTo(0);
 
         int filterMedRegistreringstyperEtterMigrering = filterRepository.tellMineFilterSomInneholderEnBestemtFiltertype(REGISTRERINGSTYPE_FILTERVALG_JSON_KEY);
         assertThat(filterMedRegistreringstyperEtterMigrering).isEqualTo(1);
@@ -309,8 +310,8 @@ class MigrerFilterServiceTest extends AbstractTest {
         migrerFilterService.migrerFilterMedFiltertype(BATCH_STORRELSE_ALLE, REGISTRERINGSTYPE_FILTERVALG_JSON_KEY);
 
         // Then
-//        int  filterMedUtdaterteRegistreringstyperEtterMigrering = filterRepository.tellMineFilterSomInneholderUtdaterteRegistreringstyper();
-//        assertThat(filterMedUtdaterteRegistreringstyperEtterMigrering).isEqualTo(0);
+        List<FilterModel> filterMedUtdaterteRegistreringstyperEtterMigrering = filterRepository.hentMineFilterSomInneholderUtdaterteRegistreringstyper();
+        assertThat(filterMedUtdaterteRegistreringstyperEtterMigrering.size()).isEqualTo(0);
 
         int filterMedRegistreringstyperEtterMigrering = filterRepository.tellMineFilterSomInneholderEnBestemtFiltertype(REGISTRERINGSTYPE_FILTERVALG_JSON_KEY);
         assertThat(filterMedRegistreringstyperEtterMigrering).isEqualTo(3);

--- a/src/test/java/no/nav/pto/veilarbfilter/service/MigrerFilterServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbfilter/service/MigrerFilterServiceTest.java
@@ -46,8 +46,8 @@ class MigrerFilterServiceTest extends AbstractTest {
     void migrer_filter_skal_migrere_filter_riktig_når_bruker_kun_har_arena_hovedmal_fra_før() {
         // Given
         // Kun folk som har filter som er migreringsverdige skal migrerast
-        String veilederId1 = "01010111111";
-        String veilederId2 = "02020222222";
+        String veilederId1 = "Z111111";
+        String veilederId2 = "Z222222";
 
         PortefoljeFilter filterMedHovedmal = new PortefoljeFilter();
         filterMedHovedmal.setHovedmal(List.of(SKAFFEA.name()));
@@ -90,8 +90,8 @@ class MigrerFilterServiceTest extends AbstractTest {
     void migrer_filter_skal_migrere_filter_riktig_når_bruker_kun_har_arena_innsatsgruppe_fra_før() {
         // Given
         // Kun folk som har filter som er migreringsverdige skal migrerast
-        String veilederId1 = "01010111111";
-        String veilederId2 = "02020222222";
+        String veilederId1 = "Z111111";
+        String veilederId2 = "Z222222";
 
         PortefoljeFilter filterMedInnsatsgruppe = new PortefoljeFilter();
         filterMedInnsatsgruppe.setInnsatsgruppe(List.of(BFORM.name()));
@@ -134,7 +134,7 @@ class MigrerFilterServiceTest extends AbstractTest {
     void migrer_filter_skal_migrere_filter_riktig_når_bruker_har_arena_hovedmal_og_gjeldende_vedtak_hovedmål_fra_før() {
         // Given
         // Kun folk som har filter som er migreringsverdige skal migrerast
-        String veilederId = "01010111111";
+        String veilederId = "Z111111";
 
         PortefoljeFilter filterMedMangeArenaHovedmalOgGjeldendeVedtakHovedmal = new PortefoljeFilter();
         filterMedMangeArenaHovedmalOgGjeldendeVedtakHovedmal.setHovedmal(List.of(SKAFFEA.name(), BEHOLDEA.name(), OKEDELT.name()));
@@ -161,7 +161,7 @@ class MigrerFilterServiceTest extends AbstractTest {
     @Test
     void migrer_filter_skal_migrere_filter_riktig_når_bruker_har_mange_filter_valg_satt_inkludert_hovedmål() {
         // Given
-        String veilederId = "01010111111";
+        String veilederId = "Z111111";
 
         PortefoljeFilter filterMedMangeFiltervalgInkludertHovedmål = new PortefoljeFilter();
         filterMedMangeFiltervalgInkludertHovedmål.setHovedmal(List.of(SKAFFEA.name(), BEHOLDEA.name(), OKEDELT.name()));
@@ -219,8 +219,8 @@ class MigrerFilterServiceTest extends AbstractTest {
     @Test
     void test_for_når_vi_vil_se_logging() {
         // Given
-        String veilederId1 = "01010111111";
-        String veilederId2 = "02020222222";
+        String veilederId1 = "Z111111";
+        String veilederId2 = "Z222222";
 
         PortefoljeFilter filterMedHovedmal = new PortefoljeFilter();
         filterMedHovedmal.setHovedmal(List.of(SKAFFEA.name()));
@@ -272,7 +272,7 @@ class MigrerFilterServiceTest extends AbstractTest {
         int filterId = mineLagredeFilterRepository.lagreFilter(veilederId, new NyttFilterModel("Filter med registreringstyper", filterMedRegistreringstyper)).get().getFilterId();
 
         // When
-        migrerFilterService.migrerFilterMedFiltertype(BATCH_STORRELSE_ALLE, REGISTRERINGSTYPE_FILTERVALG_JSON_KEY);
+        migrerFilterService.migrerFilterMedUtdaterteRegistreringstyper(BATCH_STORRELSE_ALLE);
 
         // Then
         List<FilterModel>  filterMedUtdaterteRegistreringstyperEtterMigrering = filterRepository.hentMineFilterSomInneholderUtdaterteRegistreringstyper();
@@ -307,7 +307,7 @@ class MigrerFilterServiceTest extends AbstractTest {
         int filterIdVilFortsetteIJobb = mineLagredeFilterRepository.lagreFilter(veilederId, new NyttFilterModel("Filter 3", filterVilFortsetteIJobb)).get().getFilterId();
 
         // When
-        migrerFilterService.migrerFilterMedFiltertype(BATCH_STORRELSE_ALLE, REGISTRERINGSTYPE_FILTERVALG_JSON_KEY);
+        migrerFilterService.migrerFilterMedUtdaterteRegistreringstyper(BATCH_STORRELSE_ALLE);
 
         // Then
         List<FilterModel> filterMedUtdaterteRegistreringstyperEtterMigrering = filterRepository.hentMineFilterSomInneholderUtdaterteRegistreringstyper();
@@ -332,5 +332,4 @@ class MigrerFilterServiceTest extends AbstractTest {
         assertThat(faktiskMigrertFilterJobbOver2Aar.getRegistreringstype()).isEqualTo(forventetFilterJobbOver2Aar.getRegistreringstype());
         assertThat(faktiskMigrertFilterVilFortsetteIJobb.getRegistreringstype()).isEqualTo(forventetFilterVilFortsetteIJobb.getRegistreringstype());
     }
-
 }

--- a/src/test/java/no/nav/pto/veilarbfilter/service/MigrerFilterServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbfilter/service/MigrerFilterServiceTest.java
@@ -15,7 +15,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.List;
-import java.util.Optional;
 
 import static no.nav.pto.veilarbfilter.domene.value.ArenaHovedmal.*;
 import static no.nav.pto.veilarbfilter.domene.value.ArenaInnsatsgruppe.*;
@@ -215,45 +214,45 @@ class MigrerFilterServiceTest extends AbstractTest {
         PortefoljeFilter faktiskMigrertFilter = mineLagredeFilterRepository.hentFilter(filterId, false).get().getFilterValg();
         assertThat(faktiskMigrertFilter).isEqualTo(forventetMigrertFilterMedMangeHovedmal);
     }
-
-    @Test
-    void test_for_når_vi_vil_se_logging() {
-        // Given
-        String veilederId1 = "Z111111";
-        String veilederId2 = "Z222222";
-
-        PortefoljeFilter filterMedHovedmal = new PortefoljeFilter();
-        filterMedHovedmal.setHovedmal(List.of(SKAFFEA.name()));
-
-        PortefoljeFilter filterMedMangeHovedmal = new PortefoljeFilter();
-        filterMedMangeHovedmal.setHovedmal(List.of(SKAFFEA.name(), BEHOLDEA.name(), OKEDELT.name()));
-
-        PortefoljeFilter filterMedInnsatsgruppe = new PortefoljeFilter();
-        filterMedInnsatsgruppe.setInnsatsgruppe(List.of(BFORM.name()));
-
-        PortefoljeFilter filterMedMangeInnsatsgrupper = new PortefoljeFilter();
-        filterMedMangeInnsatsgrupper.setInnsatsgruppe(List.of(BATT.name(), BFORM.name(), IKVAL.name(), VARIG.name()));
-
-        mineLagredeFilterRepository.lagreFilter(veilederId1, new NyttFilterModel("filter med hovedmål, veileder 1", filterMedHovedmal)).get().getFilterId();
-        mineLagredeFilterRepository.lagreFilter(veilederId1, new NyttFilterModel("filter med mange hovedmål, veileder 1", filterMedMangeHovedmal)).get().getFilterId();
-        mineLagredeFilterRepository.lagreFilter(veilederId2, new NyttFilterModel("filter med hovedmål, veileder 2", filterMedHovedmal)).get().getFilterId();
-        mineLagredeFilterRepository.lagreFilter(veilederId2, new NyttFilterModel("filter med mange hovedmål, veileder 2", filterMedMangeHovedmal)).get().getFilterId();
-        mineLagredeFilterRepository.lagreFilter(veilederId1, new NyttFilterModel("filter med innsatsgruppe, veileder 1", filterMedInnsatsgruppe)).get().getFilterId();
-        mineLagredeFilterRepository.lagreFilter(veilederId1, new NyttFilterModel("filter med mange innsatsgrupper, veileder 1", filterMedMangeInnsatsgrupper)).get().getFilterId();
-        mineLagredeFilterRepository.lagreFilter(veilederId2, new NyttFilterModel("filter med innsatsgruppe, veileder 2", filterMedInnsatsgruppe)).get().getFilterId();
-        mineLagredeFilterRepository.lagreFilter(veilederId2, new NyttFilterModel("filter med mange innsatsgrupper, veileder 2", filterMedMangeInnsatsgrupper)).get().getFilterId();
-
-        // When
-        Optional<MigrerFilterService.FilterMigreringResultat> resultatAvMigrering = migrerFilterService.migrerFilter(100);
-
-        // Then
-        assertThat(resultatAvMigrering.get().hovedmal().get().totalt()).isEqualTo(4);
-        assertThat(resultatAvMigrering.get().hovedmal().get().forsoktMigrert()).isEqualTo(4);
-        assertThat(resultatAvMigrering.get().hovedmal().get().faktiskMigrert()).isEqualTo(4);
-        assertThat(resultatAvMigrering.get().innsatsgruppe().get().totalt()).isEqualTo(4);
-        assertThat(resultatAvMigrering.get().innsatsgruppe().get().forsoktMigrert()).isEqualTo(4);
-        assertThat(resultatAvMigrering.get().innsatsgruppe().get().faktiskMigrert()).isEqualTo(4);
-    }
+//
+//    @Test
+//    void test_for_migrering_av_innsatsgruppe_og_hovedmal() {
+//        // Given
+//        String veilederId1 = "Z111111";
+//        String veilederId2 = "Z222222";
+//
+//        PortefoljeFilter filterMedHovedmal = new PortefoljeFilter();
+//        filterMedHovedmal.setHovedmal(List.of(SKAFFEA.name()));
+//
+//        PortefoljeFilter filterMedMangeHovedmal = new PortefoljeFilter();
+//        filterMedMangeHovedmal.setHovedmal(List.of(SKAFFEA.name(), BEHOLDEA.name(), OKEDELT.name()));
+//
+//        PortefoljeFilter filterMedInnsatsgruppe = new PortefoljeFilter();
+//        filterMedInnsatsgruppe.setInnsatsgruppe(List.of(BFORM.name()));
+//
+//        PortefoljeFilter filterMedMangeInnsatsgrupper = new PortefoljeFilter();
+//        filterMedMangeInnsatsgrupper.setInnsatsgruppe(List.of(BATT.name(), BFORM.name(), IKVAL.name(), VARIG.name()));
+//
+//        mineLagredeFilterRepository.lagreFilter(veilederId1, new NyttFilterModel("filter med hovedmål, veileder 1", filterMedHovedmal)).get().getFilterId();
+//        mineLagredeFilterRepository.lagreFilter(veilederId1, new NyttFilterModel("filter med mange hovedmål, veileder 1", filterMedMangeHovedmal)).get().getFilterId();
+//        mineLagredeFilterRepository.lagreFilter(veilederId2, new NyttFilterModel("filter med hovedmål, veileder 2", filterMedHovedmal)).get().getFilterId();
+//        mineLagredeFilterRepository.lagreFilter(veilederId2, new NyttFilterModel("filter med mange hovedmål, veileder 2", filterMedMangeHovedmal)).get().getFilterId();
+//        mineLagredeFilterRepository.lagreFilter(veilederId1, new NyttFilterModel("filter med innsatsgruppe, veileder 1", filterMedInnsatsgruppe)).get().getFilterId();
+//        mineLagredeFilterRepository.lagreFilter(veilederId1, new NyttFilterModel("filter med mange innsatsgrupper, veileder 1", filterMedMangeInnsatsgrupper)).get().getFilterId();
+//        mineLagredeFilterRepository.lagreFilter(veilederId2, new NyttFilterModel("filter med innsatsgruppe, veileder 2", filterMedInnsatsgruppe)).get().getFilterId();
+//        mineLagredeFilterRepository.lagreFilter(veilederId2, new NyttFilterModel("filter med mange innsatsgrupper, veileder 2", filterMedMangeInnsatsgrupper)).get().getFilterId();
+//
+//        // When
+//        Optional<MigrerFilterService.FilterMigreringResultat> resultatAvMigrering = migrerFilterService.migrerFilter(100);
+//
+//        // Then
+//        assertThat(resultatAvMigrering.get().hovedmal().get().totalt()).isEqualTo(4);
+//        assertThat(resultatAvMigrering.get().hovedmal().get().forsoktMigrert()).isEqualTo(4);
+//        assertThat(resultatAvMigrering.get().hovedmal().get().faktiskMigrert()).isEqualTo(4);
+//        assertThat(resultatAvMigrering.get().innsatsgruppe().get().totalt()).isEqualTo(4);
+//        assertThat(resultatAvMigrering.get().innsatsgruppe().get().forsoktMigrert()).isEqualTo(4);
+//        assertThat(resultatAvMigrering.get().innsatsgruppe().get().faktiskMigrert()).isEqualTo(4);
+//    }
 
     @Test
     void migrer_filter_skal_migrere_registreringstypefilter_riktig_når_det_også_er_nye_registreringstyper_i_filteret() {


### PR DESCRIPTION
Migrerer gamle/utdaterte registreringstypar til nye og tilsvarande registreringstypar.

Når feature-toggle er på vert det køyrd ein batch med migreringar med eit tidsopphald mellom. Migreringskoden held fram med å køyre til toggle vert skrudd av att.
Under køyringa vert det logga statusoppdateringar med kor mange filter som er migrert og kor mange som er att.
