### PR TITLE
Migrer TRENGER_VURDERING i lagra filter

### DIFF
--- a/src/main/java/no/nav/pto/veilarbfilter/config/ScheduleConfig.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/config/ScheduleConfig.java
@@ -55,11 +55,13 @@ public class ScheduleConfig {
     @Scheduled(cron = "0 0 2 16 May *")
     public void migrerTrengerVurderingTilTrengerOppfolgingsvedtak() {
         String jobbNavn = "Migrer TRENGER_VURDERING til TRENGER_OPPFOLGINGSVEDTAK";
+        
         //language=postgresql
         String antallSql = """
                 select count(*) from filter
                 where valgte_filter->'ferdigfilterListe' @> '["TRENGER_VURDERING"]'::jsonb;
                 """;
+
         //language=postgresql
         String migrerSql = """
                 UPDATE filter
@@ -70,7 +72,6 @@ public class ScheduleConfig {
         if (leaderElectionClient.isLeader()) {
             log.info("Jobb starter: {}", jobbNavn);
             try {
-
                 Optional.ofNullable(jdbcTemplate.queryForObject(antallSql, Integer.class)).ifPresent(antall ->
                         log.info("Antall filter med TRENGER_VURDERING før migrering: {}.", antall)
                 );

--- a/src/main/java/no/nav/pto/veilarbfilter/config/ScheduleConfig.java
+++ b/src/main/java/no/nav/pto/veilarbfilter/config/ScheduleConfig.java
@@ -5,10 +5,13 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.common.job.leader_election.LeaderElectionClient;
 import no.nav.pto.veilarbfilter.service.MetricsReporter;
 import no.nav.pto.veilarbfilter.service.VeilederGrupperService;
+import no.nav.pto.veilarbfilter.util.SecureLogUtils;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -19,6 +22,7 @@ public class ScheduleConfig {
     private final LeaderElectionClient leaderElectionClient;
     private final VeilederGrupperService veilederGrupperService;
     private final MetricsReporter metricsReporter;
+    private final JdbcTemplate jdbcTemplate;
 
     @Scheduled(fixedDelay = 30, initialDelay = 2, timeUnit = TimeUnit.MINUTES)
     public void fjernVeilederSomErIkkeAktive() {
@@ -45,6 +49,47 @@ public class ScheduleConfig {
             }
         } catch (Exception e) {
             log.warn("Exception during metrics reporting " + e, e);
+        }
+    }
+
+    @Scheduled(cron = "0 0 2 16 May *")
+    public void migrerTrengerVurderingTilTrengerOppfolgingsvedtak() {
+        String jobbNavn = "Migrer TRENGER_VURDERING til TRENGER_OPPFOLGINGSVEDTAK";
+        //language=postgresql
+        String antallSql = """
+                select count(*) from filter
+                where valgte_filter->'ferdigfilterListe' @> '["TRENGER_VURDERING"]'::jsonb;
+                """;
+        //language=postgresql
+        String migrerSql = """
+                UPDATE filter
+                SET valgte_filter = replace(valgte_filter::text, '"TRENGER_VURDERING"', '"TRENGER_OPPFOLGINGSVEDTAK"')::jsonb
+                where valgte_filter->'ferdigfilterListe' @> '["TRENGER_VURDERING"]'::jsonb;
+                """;
+
+        if (leaderElectionClient.isLeader()) {
+            log.info("Jobb starter: {}", jobbNavn);
+            try {
+
+                Optional.ofNullable(jdbcTemplate.queryForObject(antallSql, Integer.class)).ifPresent(antall ->
+                        log.info("Antall filter med TRENGER_VURDERING før migrering: {}.", antall)
+                );
+
+                jdbcTemplate.update(migrerSql);
+            } catch (RuntimeException e) {
+                log.error("Jobb feilet: {}. Se SecureLogs for stacktrace.", jobbNavn);
+                SecureLogUtils.secureLog.error(String.format("Jobb feilet: %s.", jobbNavn), e);
+            }
+
+            try {
+                Optional.ofNullable(jdbcTemplate.queryForObject(antallSql, Integer.class)).ifPresent(antall ->
+                        log.info("Antall filter med TRENGER_VURDERING etter migrering: {}.", antall)
+                );
+            } catch (RuntimeException e) {
+                return;
+            }
+
+            log.info("Jobb fullført: {}", jobbNavn);
         }
     }
 }

--- a/src/test/java/no/nav/pto/veilarbfilter/rest/MineLagredeFilterTest.java
+++ b/src/test/java/no/nav/pto/veilarbfilter/rest/MineLagredeFilterTest.java
@@ -408,7 +408,7 @@ public class MineLagredeFilterTest extends AbstractTest {
         aktiviteter.setIJOBB("N");
         val alderVelg = List.of("19-og-under", "20-24", "25-29", "30-39", "40-49", "50-59", "60-66", "67-70");
         val kjonnVelg = List.of("K", "M");
-        val ferdigfilterListe = List.of("UFORDELTE_BRUKERE", "NYE_BRUKERE_FOR_VEILEDER", "TRENGER_VURDERING", "INAKTIVE_BRUKERE", "VENTER_PA_SVAR_FRA_NAV", "VENTER_PA_SVAR_FRA_BRUKER", "UTLOPTE_AKTIVITETER");
+        val ferdigfilterListe = List.of("UFORDELTE_BRUKERE", "NYE_BRUKERE_FOR_VEILEDER", "TRENGER_OPPFOLGINGSVEDTAK", "INAKTIVE_BRUKERE", "VENTER_PA_SVAR_FRA_NAV", "VENTER_PA_SVAR_FRA_BRUKER", "UTLOPTE_AKTIVITETER");
         return new PortefoljeFilter(aktiviteter, List.of(alderVelg.get(random.nextInt(7)), alderVelg.get(random.nextInt(7)),
                 alderVelg.get(random.nextInt(7))), List.of(ferdigfilterListe.get(random.nextInt(6)),
                 ferdigfilterListe.get(random.nextInt(6)), ferdigfilterListe.get(random.nextInt(6))),


### PR DESCRIPTION
Legg til ein planlagt jobb som køyrer 02:00 16. mars (kvart år, i teorien, men vi skal fjerne koden igjen før det skjer).

Jobben migrerer alle "TRENGER_VURDERING"-filter i tabellen til å bruke "TRENGER_OPPFOLGINGSVEDTAK" i staden, sidan sistnevnte filter tek over "oppgåva" til Trenger vurdering.