### PR TITLE
Replicas min

### DIFF
--- a/.nais/application/application-config-prod.yaml
+++ b/.nais/application/application-config-prod.yaml
@@ -58,7 +58,7 @@ spec:
   secureLogs:
     enabled: true
   replicas:
-    min: 1
+    min: 2
     max: 2
     cpuThresholdPercentage: 50
   prometheus:


### PR DESCRIPTION
Vi har hatt ein del tilfeller av "Applikasjon er nede"-alarmen i det siste. [Seinast i dag](https://nav-it.slack.com/archives/C02DL8MNC9W/p1748425304713129).

Etter å ha rådført meg med Nais trur eg dette heng saman med at vi har spesifisert `replicas.min` til å vere `1` for veilarbfilter, sjølv om anbefalt minimum er `2`. Det står litt meir om dette i [denne Slack-tråden](https://nav-it.slack.com/archives/C5KUST8N6/p1748430748499429) og i [Nais-docen](https://doc.nav.cloud.nais.io/workloads/explanations/good-practices/index.html#run-multiple-replicas).

Legg ved utdrag frå Nais-docen:

> ## Run multiple replicas[¶](https://doc.nav.cloud.nais.io/workloads/explanations/good-practices/index.html#run-multiple-replicas)
> 
> The way Kubernetes operates relies on the fact that a system should be self-correcting over time. In order to facilitate this, the system responds to changes in various ways which will affect applications running on the platform. One of those ways is to restart pods, or move pods to other nodes if needed. This can also happen when you deploy a new version, if your use the Recreate rollout strategy.
> 
> If your application only has a single replica, then your users will experience downtime whenever your pod is restarted or moved.
> 
> If you wish to avoid unnecessary downtime, your application should run at least 2 replicas.
> 
> If your application functions in a way that requires that only a single pod is active, you can employ [leader election](https://doc.nav.cloud.nais.io/services/leader-election/) to select a leader that does the work, while keeping a running backup replica ready to step in should the leader be killed.