### PR TITLE
Ekskluderer tomcat-embed-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,10 +79,20 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
for å fjerne sårbarhetene CVE-2025-48988, GHSA-h3gc-qfqq-6h8f, GHSA-wc4r-xq3c-5cf3 og CVE-2025-49125.
I følge copiloten er Jetty et godt valg for mikrotjenester. 